### PR TITLE
Update system requirements to .NET 6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -19,7 +19,7 @@ The latest stable release is v4.5 (2020-03-31)
 
 * Requirements:
 
-Obi will run on Windows Vista, Windows 7, Windows 8 & Windows 10. It needs .NET framework 4.0, DirectX 9 c and 32 bit Java runtime environment 6.0 & above.
+Obi will run on Windows Vista, Windows 7, Windows 8 & Windows 10. It needs .NET framework 6.0, DirectX 9 c and 32 bit Java runtime environment 6.0 & above.
 
 All of these dependencies will be installed by installer during installation process. To install Obi, please go through installation guide.
 


### PR DESCRIPTION
## Description

This PR updates the system requirements in `readme.txt` to reflect the correct .NET framework version.

## Changes

- Changed `.NET framework 4.0` to `.NET framework 6.0` in the Requirements section of `readme.txt`

## Related Issue

Closes #224

As reported in issue #224, users installing Obi 5.0 beta on Windows 11 were encountering errors indicating that the .NET framework was not installed. The readme.txt incorrectly listed .NET framework 4.0 as the requirement, when the application actually requires .NET 6.0. This update corrects the documentation to reflect the proper system requirements.